### PR TITLE
Add dark mode support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,15 +1,15 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
-  --background: #ffffff;
+  --background: #f3f4f6;
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: #111827;
+  --foreground: #f3f4f6;
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 
 export const metadata: Metadata = {
   title: "Kanban for Coding Agents",
@@ -12,9 +13,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
-        {children}
+        <ThemeProvider>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useTasks } from '@/hooks/useTasks';
 import { useAgents } from '@/hooks/useAgents';
 import { KanbanBoard } from '@/components/KanbanBoard';
+import { ThemeToggle } from '@/components/ThemeToggle';
 
 export default function Home() {
   const { tasks, addTask, updateTask, deleteTask, isLoaded: tasksLoaded } = useTasks();
@@ -10,14 +11,17 @@ export default function Home() {
 
   if (!tasksLoaded || !agentsLoaded) {
     return (
-      <div className="flex items-center justify-center min-h-screen text-gray-400">
+      <div className="flex items-center justify-center min-h-screen text-gray-400 dark:text-gray-500">
         Loading kanban board...
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 p-4">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4 transition-colors">
+      <div className="fixed top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
       <main className="max-w-[1800px] mx-auto h-[calc(100vh-2rem)]">
         <KanbanBoard
           tasks={tasks}

--- a/src/components/AgentSelector.tsx
+++ b/src/components/AgentSelector.tsx
@@ -16,9 +16,9 @@ export const AgentSelector = ({ task, agents, onAssign }: AgentSelectorProps) =>
   if (assignedAgent) {
     const avatarColor = assignedAgent.avatarColor || getAvatarColor(assignedAgent.name);
     return (
-      <div className="flex items-center justify-between p-2 bg-blue-50 rounded-lg border border-blue-200">
+      <div className="flex items-center justify-between p-2 bg-blue-50 dark:bg-blue-900/30 rounded-lg border border-blue-200 dark:border-blue-800">
         <div className="flex items-center gap-2">
-          <div 
+          <div
             className={clsx(
               "w-5 h-5 rounded-full flex items-center justify-center text-white text-[10px] font-semibold",
               avatarColor
@@ -26,11 +26,11 @@ export const AgentSelector = ({ task, agents, onAssign }: AgentSelectorProps) =>
           >
             {assignedAgent.avatar || getInitials(assignedAgent.name)}
           </div>
-          <span className="text-xs font-medium text-blue-700">{assignedAgent.name}</span>
+          <span className="text-xs font-medium text-blue-700 dark:text-blue-300">{assignedAgent.name}</span>
         </div>
         <button
           onClick={() => onAssign(undefined)}
-          className="text-blue-400 hover:text-blue-600"
+          className="text-blue-400 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
           title="Unassign agent"
         >
           <X size={14} />
@@ -43,7 +43,7 @@ export const AgentSelector = ({ task, agents, onAssign }: AgentSelectorProps) =>
     <select
       value=""
       onChange={(e) => onAssign(e.target.value || undefined)}
-      className="w-full text-xs border border-gray-200 rounded-lg p-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+      className="w-full text-xs border border-gray-200 dark:border-gray-600 rounded-lg p-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500/20 dark:focus:ring-blue-400/20"
     >
       <option value="">Assign to agent...</option>
       {agents.map(agent => (

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Task, TaskStatus } from '@/types/task';
 import { CodingAgent } from '@/types/agent';
 import { generateId, generateTaskId } from '@/lib/utils';
@@ -68,8 +68,9 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
       setNewTaskTags('');
       setNewTaskPriority(3);
       setIsAdding(false);
-    } catch (err: any) {
-      setError(err.message || 'Failed to add task. Please try again.');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to add task. Please try again.';
+      setError(message);
       console.error(err);
     }
   };
@@ -93,10 +94,10 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
     <div className="flex flex-col h-full overflow-hidden">
       {/* Toolbar */}
       <div className="mb-4 flex justify-between items-center">
-        <h2 className="text-xl font-bold">Coding Agents Kanban</h2>
-        <button 
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white">Coding Agents Kanban</h2>
+        <button
           onClick={() => setIsAdding(true)}
-          className="bg-black text-white px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-2 hover:bg-gray-800"
+          className="bg-black dark:bg-white text-white dark:text-black px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-2 hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors"
         >
           <Plus size={16} /> New Task
         </button>
@@ -104,22 +105,22 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
 
       {isAdding && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={() => setIsAdding(false)}>
-          <div className="bg-white p-6 rounded-xl w-full max-w-md shadow-xl" onClick={(e) => e.stopPropagation()}>
+          <div className="bg-white dark:bg-gray-800 p-6 rounded-xl w-full max-w-md shadow-xl" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-bold">Add New Task</h3>
-              <button 
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white">Add New Task</h3>
+              <button
                 onClick={() => setIsAdding(false)}
-                className="text-gray-400 hover:text-gray-600"
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
               >
                 <X size={20} />
               </button>
             </div>
             <form onSubmit={(e) => handleAdd(e, 'backlog')} className="space-y-4">
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Task Title *</label>
-                <input 
-                  className="w-full border border-gray-200 p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10" 
-                  placeholder="e.g., Implement user authentication" 
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Task Title *</label>
+                <input
+                  className="w-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10 dark:focus:ring-white/20"
+                  placeholder="e.g., Implement user authentication"
                   value={newTaskTitle}
                   onChange={e => setNewTaskTitle(e.target.value)}
                   autoFocus
@@ -127,18 +128,18 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Description (optional)</label>
-                <textarea 
-                  className="w-full border border-gray-200 p-2.5 rounded-lg h-24 focus:outline-none focus:ring-2 focus:ring-black/10 resize-none" 
-                  placeholder="Describe the task in detail..." 
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Description (optional)</label>
+                <textarea
+                  className="w-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white p-2.5 rounded-lg h-24 focus:outline-none focus:ring-2 focus:ring-black/10 dark:focus:ring-white/20 resize-none"
+                  placeholder="Describe the task in detail..."
                   value={newTaskDesc}
                   onChange={e => setNewTaskDesc(e.target.value)}
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Priority (1-5)</label>
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Priority (1-5)</label>
                 <select
-                  className="w-full border border-gray-200 p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10"
+                  className="w-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10 dark:focus:ring-white/20"
                   value={newTaskPriority}
                   onChange={e => setNewTaskPriority(Number(e.target.value) as 1 | 2 | 3 | 4 | 5)}
                 >
@@ -150,22 +151,22 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
                 </select>
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">Tags (comma-separated)</label>
-                <input 
-                  className="w-full border border-gray-200 p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10" 
-                  placeholder="e.g., frontend, urgent, bug" 
+                <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Tags (comma-separated)</label>
+                <input
+                  className="w-full border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-white p-2.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-black/10 dark:focus:ring-white/20"
+                  placeholder="e.g., frontend, urgent, bug"
                   value={newTaskTags}
                   onChange={e => setNewTaskTags(e.target.value)}
                 />
               </div>
               {error && (
-                <div className="p-2 bg-red-50 border border-red-200 rounded text-xs text-red-600">
+                <div className="p-2 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded text-xs text-red-600 dark:text-red-400">
                   {error}
                 </div>
               )}
               <div className="flex justify-end gap-2 pt-2">
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   onClick={() => {
                     setIsAdding(false);
                     setNewTaskTitle('');
@@ -173,14 +174,14 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
                     setNewTaskTags('');
                     setNewTaskPriority(3);
                     setError(null);
-                  }} 
-                  className="px-4 py-2 text-gray-600 hover:text-gray-800 transition-colors"
+                  }}
+                  className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
                 >
                   Cancel
                 </button>
-                <button 
-                  type="submit" 
-                  className="px-4 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors font-medium"
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-black dark:bg-white text-white dark:text-black rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors font-medium"
                 >
                   Add Task
                 </button>
@@ -192,7 +193,7 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
 
       {/* Error Display */}
       {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-600 dark:text-red-400">
           {error}
         </div>
       )}
@@ -203,10 +204,10 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
           {COLUMNS.map((col, colIdx) => {
             const columnTasks = tasks.filter(t => t.status === col.id);
             return (
-              <div key={col.id} className="flex-1 bg-gray-50 rounded-lg flex flex-col max-h-full border border-gray-200">
-                <div className="p-3 font-bold text-sm text-gray-600 uppercase tracking-wider border-b border-gray-200 flex justify-between items-center">
+              <div key={col.id} className="flex-1 bg-gray-50 dark:bg-gray-800 rounded-lg flex flex-col max-h-full border border-gray-200 dark:border-gray-700">
+                <div className="p-3 font-bold text-sm text-gray-600 dark:text-gray-300 uppercase tracking-wider border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
                   <span>{col.title}</span>
-                  <span className="bg-gray-200 text-gray-700 px-2.5 py-0.5 rounded-full text-xs font-semibold">
+                  <span className="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-2.5 py-0.5 rounded-full text-xs font-semibold">
                     {columnTasks.length}
                   </span>
                 </div>
@@ -215,7 +216,7 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
                   {col.id === 'backlog' && (
                     <button
                       onClick={() => setIsAdding(true)}
-                      className="w-full p-3 border-2 border-dashed border-gray-300 rounded-lg text-gray-400 hover:border-gray-400 hover:text-gray-600 transition-colors flex items-center justify-center gap-2 text-sm font-medium mb-2"
+                      className="w-full p-3 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-gray-400 dark:text-gray-500 hover:border-gray-400 dark:hover:border-gray-500 hover:text-gray-600 dark:hover:text-gray-400 transition-colors flex items-center justify-center gap-2 text-sm font-medium mb-2"
                     >
                       <Plus size={16} />
                       Add Task
@@ -223,40 +224,40 @@ export const KanbanBoard = ({ tasks, agents, onAddTask, onUpdateTask, onDeleteTa
                   )}
                   {/* Empty state */}
                   {tasks.length === 0 && col.id === 'backlog' && (
-                    <div className="text-center py-8 text-gray-400 text-sm">
+                    <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">
                       <p className="mb-1">No tasks yet</p>
                       <p className="text-xs">Click &quot;Add Task&quot; above to get started</p>
                     </div>
                   )}
                   {/* Show message if this column is empty but other columns have items */}
                   {tasks.length > 0 && columnTasks.length === 0 && (
-                    <div className="text-center py-4 text-gray-400 text-xs">
+                    <div className="text-center py-4 text-gray-400 dark:text-gray-500 text-xs">
                       No items in {col.title.toLowerCase()}
                     </div>
                   )}
                   {columnTasks.map(task => (
                     <div key={task.id} className="relative">
-                      <TaskItem 
-                        task={task} 
+                      <TaskItem
+                        task={task}
                         agents={agents}
-                        onUpdate={onUpdateTask} 
-                        onDelete={onDeleteTask} 
+                        onUpdate={onUpdateTask}
+                        onDelete={onDeleteTask}
                       />
                       <div className="mt-2 flex items-center justify-between px-1">
                         {colIdx > 0 ? (
-                          <button 
-                            onClick={() => handleMove(task, 'prev')} 
-                            className="text-gray-400 hover:text-black text-xs flex items-center gap-1"
+                          <button
+                            onClick={() => handleMove(task, 'prev')}
+                            className="text-gray-400 hover:text-black dark:hover:text-white text-xs flex items-center gap-1 transition-colors"
                           >
                             <ArrowLeft size={14} />
                             Prev
                           </button>
                         ) : <div />}
-                        
+
                         {colIdx < COLUMNS.length - 1 ? (
-                          <button 
-                            onClick={() => handleMove(task, 'next')} 
-                            className="text-gray-400 hover:text-black text-xs flex items-center gap-1"
+                          <button
+                            onClick={() => handleMove(task, 'next')}
+                            className="text-gray-400 hover:text-black dark:hover:text-white text-xs flex items-center gap-1 transition-colors"
                           >
                             Next
                             <ArrowRight size={14} />

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -11,59 +11,59 @@ interface TaskItemProps {
   onDelete: (id: string) => void;
 }
 
-export const TaskItem = ({ task, agents, onUpdate, onDelete }: TaskItemProps) => {
+export const TaskItem = ({ task, agents, onDelete }: TaskItemProps) => {
   const assignedAgent = agents.find(a => a.id === task.assignedAgentId);
 
   const tagColors: { [key: string]: string } = {
-    'frontend': 'bg-blue-100 text-blue-700 border-blue-200',
-    'backend': 'bg-green-100 text-green-700 border-green-200',
-    'bug': 'bg-red-100 text-red-700 border-red-200',
-    'feature': 'bg-purple-100 text-purple-700 border-purple-200',
-    'urgent': 'bg-orange-100 text-orange-700 border-orange-200',
-    'api': 'bg-indigo-100 text-indigo-700 border-indigo-200',
-    'ui': 'bg-pink-100 text-pink-700 border-pink-200',
+    'frontend': 'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-800',
+    'backend': 'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/40 dark:text-green-300 dark:border-green-800',
+    'bug': 'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/40 dark:text-red-300 dark:border-red-800',
+    'feature': 'bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:border-purple-800',
+    'urgent': 'bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/40 dark:text-orange-300 dark:border-orange-800',
+    'api': 'bg-indigo-100 text-indigo-700 border-indigo-200 dark:bg-indigo-900/40 dark:text-indigo-300 dark:border-indigo-800',
+    'ui': 'bg-pink-100 text-pink-700 border-pink-200 dark:bg-pink-900/40 dark:text-pink-300 dark:border-pink-800',
   };
 
   const getTagColor = (tag: string): string => {
     const lowerTag = tag.toLowerCase();
-    return tagColors[lowerTag] || 'bg-gray-100 text-gray-700 border-gray-200';
+    return tagColors[lowerTag] || 'bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:border-gray-600';
   };
 
   const getPriorityIcon = (priority: number) => {
-    if (priority >= 4) return <ArrowUp size={14} className="text-red-600" />;
-    if (priority === 3) return <Minus size={14} className="text-yellow-600" />;
-    return <ArrowDown size={14} className="text-gray-600" />;
+    if (priority >= 4) return <ArrowUp size={14} className="text-red-600 dark:text-red-400" />;
+    if (priority === 3) return <Minus size={14} className="text-yellow-600 dark:text-yellow-400" />;
+    return <ArrowDown size={14} className="text-gray-600 dark:text-gray-400" />;
   };
 
-  const avatarColor = assignedAgent 
+  const avatarColor = assignedAgent
     ? (assignedAgent.avatarColor || getAvatarColor(assignedAgent.name))
     : 'bg-gray-400';
 
   return (
-    <div className="bg-white p-3 rounded-lg shadow-sm border border-gray-200 group relative hover:shadow-md transition-all cursor-pointer">
-      <button 
+    <div className="bg-white dark:bg-gray-700 p-3 rounded-lg shadow-sm border border-gray-200 dark:border-gray-600 group relative hover:shadow-md transition-all cursor-pointer">
+      <button
         onClick={(e) => {
           e.stopPropagation();
           onDelete(task.id);
         }}
-        className="absolute top-2 right-2 text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+        className="absolute top-2 right-2 text-gray-300 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity z-10"
       >
         <X size={14} />
       </button>
-      
+
       <div className="pr-6">
         {/* Task ID */}
-        <div className="text-xs text-gray-500 mb-1 font-mono">{task.taskId}</div>
-        
+        <div className="text-xs text-gray-500 dark:text-gray-400 mb-1 font-mono">{task.taskId}</div>
+
         {/* Title */}
-        <h4 className="font-semibold text-sm mb-2 text-gray-900 leading-tight">{task.title}</h4>
-        
+        <h4 className="font-semibold text-sm mb-2 text-gray-900 dark:text-white leading-tight">{task.title}</h4>
+
         {/* Tags */}
         {task.tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-2">
             {task.tags.map((tag, idx) => (
-              <span 
-                key={idx} 
+              <span
+                key={idx}
                 className={clsx(
                   "text-[10px] px-2 py-0.5 rounded font-semibold uppercase border",
                   getTagColor(tag)
@@ -74,35 +74,35 @@ export const TaskItem = ({ task, agents, onUpdate, onDelete }: TaskItemProps) =>
             ))}
           </div>
         )}
-        
+
         {/* Footer with icons and assignee */}
-        <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-100">
+        <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-100 dark:border-gray-600">
           <div className="flex items-center gap-2">
             {/* Priority Icon */}
             <div className="flex items-center">
               {getPriorityIcon(task.priority)}
             </div>
-            
+
             {/* Comments */}
             {task.commentsCount !== undefined && task.commentsCount > 0 && (
-              <div className="flex items-center gap-1 text-gray-500">
+              <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
                 <MessageCircle size={14} />
                 <span className="text-xs">{task.commentsCount}</span>
               </div>
             )}
-            
+
             {/* Attachments */}
             {task.attachmentsCount !== undefined && task.attachmentsCount > 0 && (
-              <div className="flex items-center gap-1 text-gray-500">
+              <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
                 <Paperclip size={14} />
                 <span className="text-xs">{task.attachmentsCount}</span>
               </div>
             )}
           </div>
-          
+
           {/* Assigned Agent Avatar */}
           {assignedAgent && (
-            <div 
+            <div
               className={clsx(
                 "w-6 h-6 rounded-full flex items-center justify-center text-white text-xs font-semibold",
                 avatarColor

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+
+export const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? (
+        <Moon size={20} className="text-gray-700" />
+      ) : (
+        <Sun size={20} className="text-yellow-400" />
+      )}
+    </button>
+  );
+};

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { createContext, useContext, useCallback, useSyncExternalStore } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+// Theme store with subscription support
+let themeCache: Theme | null = null;
+const listeners = new Set<() => void>();
+
+const getThemeSnapshot = (): Theme => {
+  if (themeCache === null) {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      themeCache = stored;
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      themeCache = 'dark';
+    } else {
+      themeCache = 'light';
+    }
+  }
+  return themeCache;
+};
+
+const getServerThemeSnapshot = (): Theme => 'light';
+
+const subscribeTheme = (callback: () => void): (() => void) => {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+};
+
+const setTheme = (newTheme: Theme) => {
+  themeCache = newTheme;
+  localStorage.setItem('theme', newTheme);
+  document.documentElement.classList.remove('light', 'dark');
+  document.documentElement.classList.add(newTheme);
+  listeners.forEach((listener) => listener());
+};
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const theme = useSyncExternalStore(subscribeTheme, getThemeSnapshot, getServerThemeSnapshot);
+
+  // Apply theme class on client
+  if (typeof window !== 'undefined') {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+  }
+
+  const toggleTheme = useCallback(() => {
+    const newTheme = themeCache === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- Add dark mode toggle button in the top-right corner
- Theme persists in localStorage and respects system preference on first visit
- All components updated with dark mode Tailwind classes
- Smooth transitions between light and dark modes

## Changes
- New `ThemeContext` using `useSyncExternalStore` for reactive theme state
- New `ThemeToggle` component with sun/moon icons
- Updated `globals.css` with Tailwind v4 dark mode variant
- Updated all components: KanbanBoard, TaskItem, AgentSelector

## Test plan
- [x] Toggle between light and dark mode
- [x] Theme persists after page refresh
- [x] Respects system preference on first visit
- [x] All UI elements visible in both modes
- [x] `npm run lint` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)